### PR TITLE
feat: 프로필 창 구현 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import HomePage from './pages/HomePage'
 import ExplorePage from './pages/ExplorePage'
 import AboutPage from './pages/AboutPage'
 import BookmarkPage from './pages/BookmarkPage'
+// ProfilePage import 추가 (모달은 지우세요)
+import ProfilePage from './pages/ProfilePage'
 
 const publicRoutes: RouteObject[] = [
   {
@@ -13,11 +15,11 @@ const publicRoutes: RouteObject[] = [
     errorElement: <NotFoundPage />,
     children: [
       { index: true, element: <HomePage /> },
-      // { path: "login", element: <LoginPage /> },
-      // { path: "signup", element: <SignupPage /> },
       { path: 'bookmark', element: <BookmarkPage /> },
       { path: 'explore', element: <ExplorePage /> },
       { path: 'about', element: <AboutPage /> },
+      // 프로필 라우트 추가
+      { path: 'profile', element: <ProfilePage /> },
     ],
   },
 ]

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -82,7 +82,14 @@ const Header = () => {
               </button>
               {isOpen && (
                 <div className="absolute right-0 z-50 w-[118px] h-36 bg-white border border-brand-500/25 shadow-lg shadow-brand-500/25 rounded-lg rounded-tr-none flex flex-col gap-3 py-4 text-center text-lg font-sans font-medium text-[#0d3c61]">
-                  <button className="hover:text-brand-500">Profile</button>
+                  {/* 여기만 수정했습니다: button -> Link */}
+                  <Link
+                    to="/profile"
+                    className="hover:text-brand-500"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    Profile
+                  </Link>
                   <button className="hover:text-brand-500">History</button>
                   <button className="hover:text-brand-500">Logout</button>
                 </div>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,0 +1,101 @@
+import { motion } from 'framer-motion'
+import profileImg from '@/assets/default_profile.png'
+// 아이콘 경로는 실제 프로젝트 위치에 맞춰주세요
+import editIcon from '@/assets/icons/common/ic_edit.svg'
+
+const ProfilePage = () => {
+  // 인풋 스타일 (피그마 디자인 적용)
+  const inputBaseStyle =
+    'w-80 h-11 bg-white rounded-[30px] shadow-[0px_3px_5px_0px_rgba(224,224,233,0.25)] border border-zinc-200 outline-none focus:border-brand-500 transition-colors pl-6 text-base font-medium text-slate-900 placeholder:text-stone-300'
+
+  return (
+    // 헤더 높이(80px)를 뺀 나머지 공간을 꽉 채우고 중앙 정렬
+    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-80px)] relative overflow-hidden pt-10 pb-20">
+      {/* [수정됨] 배경 블러 효과 
+          1. -z-10 제거 (배경 뒤로 숨는 문제 해결)
+          2. pointer-events-none 추가 (배경이 클릭을 방해하지 않도록 설정)
+          3. 홈페이지와 동일한 색상/투명도/블러 적용
+      */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[300px] h-[300px] bg-brand-500/50 rounded-full blur-[200px] pointer-events-none" />
+
+      {/* 컨텐츠 영역 (z-10으로 배경보다 위에 오도록 명시) */}
+      <div className="z-10 flex flex-col items-center gap-10">
+        {/* 1. Title */}
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-slate-900 text-3xl font-medium font-['Pretendard_Variable'] tracking-widest"
+        >
+          Profile
+        </motion.div>
+
+        {/* 2. Profile Image & Icon Area */}
+        <motion.div
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={{ opacity: 1, scale: 1 }}
+          className="relative w-48 h-48"
+        >
+          {/* 프로필 이미지 */}
+          <img
+            src={profileImg}
+            alt="Profile"
+            className="w-full h-full rounded-full border border-brand-500 object-cover bg-white shadow-sm"
+          />
+
+          {/* 편집 버튼: 이미지 우측 하단 바깥쪽으로 배치 */}
+          <motion.button
+            whileHover={{ scale: 1.1 }}
+            whileTap={{ scale: 0.9 }}
+            className="absolute bottom-2 -right-12 p-2 cursor-pointer"
+          >
+            <img src={editIcon} alt="Edit Profile" className="w-6 h-6" />
+          </motion.button>
+        </motion.div>
+
+        {/* 3. Inputs Section */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
+          className="flex flex-col gap-6 items-center"
+        >
+          {/* 닉네임 */}
+          <div className="relative w-80 h-11">
+            <input type="text" placeholder="닉네임" className={inputBaseStyle} />
+            {/* 중복 확인 버튼 */}
+            <button
+              type="button"
+              className="absolute -right-[100px] top-2 w-24 h-7 bg-white rounded-2xl border-[0.5px] border-brand-500 shadow-[0px_1px_2px_0px_rgba(33,150,243,0.25)] text-brand-500 text-sm font-medium hover:bg-brand-50 transition-colors flex items-center justify-center pb-0.5 cursor-pointer"
+            >
+              중복 확인
+            </button>
+          </div>
+
+          {/* 비밀번호 */}
+          <div className="relative w-80 h-11">
+            <input type="password" placeholder="변경 비밀번호" className={inputBaseStyle} />
+          </div>
+
+          {/* 비밀번호 확인 */}
+          <div className="relative w-80 h-11">
+            <input type="password" placeholder="변경 비밀번호 확인" className={inputBaseStyle} />
+          </div>
+        </motion.div>
+
+        {/* 4. Delete Account Button */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.2 }}
+          className="mt-4"
+        >
+          <button className="w-80 h-14 bg-white rounded-[30px] shadow-[0px_3px_5px_0px_rgba(224,224,233,0.25)] border border-zinc-200 flex justify-center items-center hover:bg-slate-50 transition-colors cursor-pointer">
+            <span className="text-zinc-400 text-base font-normal">회원 탈퇴</span>
+          </button>
+        </motion.div>
+      </div>
+    </div>
+  )
+}
+
+export default ProfilePage


### PR DESCRIPTION

## #️⃣ 연관된 이슈

#30

## #️⃣ 작업 내용
이번 PR에서는 사용자의 프로필 페이지 UI를 구현하고, 헤더와의 연결 작업을 진행했습니다.

프로필 페이지 구현 (src/pages/ProfilePage.tsx)

Figma 디자인을 반영하여 프로필 이미지, 닉네임/비밀번호 변경 입력창, 회원 탈퇴 버튼을 배치했습니다.

HomePage와 통일감을 주기 위해 배경에 은은한 원형 블러(Blur) 효과를 적용했습니다.

Framer Motion을 사용하여 페이지 진입 시 자연스러운 애니메이션을 추가했습니다.

헤더 네비게이션 수정 (src/components/Layout/Header/Header.tsx)

기존의 단순 버튼이었던 드롭다운 메뉴 내 'Profile' 항목을 Link 컴포넌트로 변경하여, 클릭 시 /profile 페이지로 이동하도록 연결했습니다.



## #️⃣ 테스트 결과

[x] 로컬 환경에서 /profile 경로 접속 시 UI가 디자인 시안대로 출력되는지 확인했습니다.

[x] 헤더의 프로필 이미지를 클릭하고 드롭다운 메뉴에서 'Profile'을 눌렀을 때 페이지가 정상적으로 이동하는지 확인했습니다.

## #️⃣ 변경 사항 체크리스트

[x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (UI 테스트 완료)
[x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)
<img width="3676" height="2570" alt="프로필창 원본캡쳐" src="https://github.com/user-attachments/assets/183284e5-f8a1-4550-ad9c-a5d668955d8e" />


## #️⃣ 리뷰 요구사항 (선택)
은은한 원형 블러(Blur) 위치 이상하진 않은지 봐주시면 좋아요.
