### PR TITLE
feat: 활동내역(History) 페이지 구현 (#31)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,8 @@ import HomePage from './pages/HomePage'
 import ExplorePage from './pages/ExplorePage'
 import AboutPage from './pages/AboutPage'
 import BookmarkPage from './pages/BookmarkPage'
-// ProfilePage import 추가 (모달은 지우세요)
 import ProfilePage from './pages/ProfilePage'
+import HistoryPage from './pages/HistoryPage' // [추가됨] import
 
 const publicRoutes: RouteObject[] = [
   {
@@ -18,8 +18,8 @@ const publicRoutes: RouteObject[] = [
       { path: 'bookmark', element: <BookmarkPage /> },
       { path: 'explore', element: <ExplorePage /> },
       { path: 'about', element: <AboutPage /> },
-      // 프로필 라우트 추가
       { path: 'profile', element: <ProfilePage /> },
+      { path: 'history', element: <HistoryPage /> },
     ],
   },
 ]

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -82,7 +82,6 @@ const Header = () => {
               </button>
               {isOpen && (
                 <div className="absolute right-0 z-50 w-[118px] h-36 bg-white border border-brand-500/25 shadow-lg shadow-brand-500/25 rounded-lg rounded-tr-none flex flex-col gap-3 py-4 text-center text-lg font-sans font-medium text-[#0d3c61]">
-                  {/* 여기만 수정했습니다: button -> Link */}
                   <Link
                     to="/profile"
                     className="hover:text-brand-500"
@@ -90,7 +89,14 @@ const Header = () => {
                   >
                     Profile
                   </Link>
-                  <button className="hover:text-brand-500">History</button>
+                  {/* 여기 수정됨: History 버튼을 Link로 변경 */}
+                  <Link
+                    to="/history"
+                    className="hover:text-brand-500"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    History
+                  </Link>
                   <button className="hover:text-brand-500">Logout</button>
                 </div>
               )}

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,0 +1,99 @@
+const HistoryPage = () => {
+  const historyData = [
+    {
+      id: 1,
+      name: '구글 api',
+      date: '2026.01.01',
+      status: '검토중',
+      changeDate: '',
+      reason: '',
+    },
+    {
+      id: 2,
+      name: '카카오톡 api',
+      date: '2026.12.30',
+      status: '통과',
+      changeDate: '2026.01.02',
+      reason: '',
+    },
+    {
+      id: 3,
+      name: '유튜브 api',
+      date: '2026.12.10',
+      status: '거절',
+      changeDate: '2026.12.11',
+      reason: '비속어',
+    },
+  ]
+
+  return (
+    <div className="relative flex min-h-[calc(100vh-80px)] w-full flex-col items-center overflow-hidden pt-20">
+      {/* 배경 원 수정됨: top-[20%] -> top-[40%] (홈페이지와 시각적 높이 맞춤) */}
+      <div className="absolute left-1/2 top-[40%] h-[300px] w-[300px] -translate-x-1/2 rounded-full bg-brand-500/50 blur-[200px]" />
+
+      <div className="z-10 flex w-full flex-col items-center">
+        {/* Title: History */}
+        <div className="mb-12 text-center text-3xl font-medium tracking-widest text-slate-900 font-['Pretendard_Variable']">
+          History
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {/* Subtitle: 편집 내역 */}
+          <div className="justify-start text-xl font-medium text-sky-900 font-['Pretendard_Variable']">
+            편집 내역
+          </div>
+
+          {/* Content Card */}
+          <div className="flex h-80 w-[1112px] flex-col items-center rounded-[20px] border border-sky-500 bg-white/80 py-8 shadow-sm backdrop-blur-sm">
+            {/* Table Header */}
+            <div className="mb-6 grid w-[1000px] grid-cols-5 text-center">
+              <div className="text-xl font-medium text-sky-900 font-['Pretendard_Variable']">
+                목록
+              </div>
+              <div className="text-xl font-medium text-sky-900 font-['Pretendard_Variable']">
+                수정일
+              </div>
+              <div className="text-xl font-medium text-sky-900 font-['Pretendard_Variable']">
+                상태
+              </div>
+              <div className="text-xl font-medium text-sky-900 font-['Pretendard_Variable']">
+                상태 변경일
+              </div>
+              <div className="text-xl font-medium text-sky-900 font-['Pretendard_Variable']">
+                사유
+              </div>
+            </div>
+
+            {/* 구분선 */}
+            <div className="mb-6 h-0 w-[1000px] outline outline-1 outline-offset-[-0.50px] outline-sky-900/50"></div>
+
+            {/* Table Body */}
+            <div className="flex w-[1000px] flex-col gap-8">
+              {historyData.map((item) => (
+                <div key={item.id} className="grid grid-cols-5 items-center text-center">
+                  <div className="text-lg font-medium text-sky-900 font-['Pretendard_Variable']">
+                    {item.name}
+                  </div>
+                  <div className="text-lg font-medium text-sky-900 font-['Pretendard_Variable']">
+                    {item.date}
+                  </div>
+                  <div className="text-lg font-medium text-sky-900 font-['Pretendard_Variable']">
+                    {item.status}
+                  </div>
+                  <div className="text-lg font-medium text-sky-900 font-['Pretendard_Variable']">
+                    {item.changeDate || ''}
+                  </div>
+                  <div className="text-lg font-medium text-sky-900 font-['Pretendard_Variable']">
+                    {item.reason || ''}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default HistoryPage

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,24 +1,20 @@
 import { motion } from 'framer-motion'
 import profileImg from '@/assets/default_profile.png'
-// 아이콘 경로는 실제 프로젝트 위치에 맞춰주세요
 import editIcon from '@/assets/icons/common/ic_edit.svg'
 
 const ProfilePage = () => {
-  // 인풋 스타일 (피그마 디자인 적용)
   const inputBaseStyle =
     'w-80 h-11 bg-white rounded-[30px] shadow-[0px_3px_5px_0px_rgba(224,224,233,0.25)] border border-zinc-200 outline-none focus:border-brand-500 transition-colors pl-6 text-base font-medium text-slate-900 placeholder:text-stone-300'
 
   return (
-    // 헤더 높이(80px)를 뺀 나머지 공간을 꽉 채우고 중앙 정렬
     <div className="flex flex-col items-center justify-center min-h-[calc(100vh-80px)] relative overflow-hidden pt-10 pb-20">
-      {/* [수정됨] 배경 블러 효과 
-          1. -z-10 제거 (배경 뒤로 숨는 문제 해결)
-          2. pointer-events-none 추가 (배경이 클릭을 방해하지 않도록 설정)
-          3. 홈페이지와 동일한 색상/투명도/블러 적용
+      {/* [수정됨] 배경 위치 조정 
+        top-1/2 -> top-[40%] (홈페이지와 동일한 높이감)
+        -translate-y-1/2 제거 (top 기준 위치 사용)
       */}
-      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[300px] h-[300px] bg-brand-500/50 rounded-full blur-[200px] pointer-events-none" />
+      <div className="absolute top-[40%] left-1/2 -translate-x-1/2 w-[300px] h-[300px] bg-brand-500/50 rounded-full blur-[200px] pointer-events-none" />
 
-      {/* 컨텐츠 영역 (z-10으로 배경보다 위에 오도록 명시) */}
+      {/* 컨텐츠 영역 */}
       <div className="z-10 flex flex-col items-center gap-10">
         {/* 1. Title */}
         <motion.div
@@ -35,14 +31,12 @@ const ProfilePage = () => {
           animate={{ opacity: 1, scale: 1 }}
           className="relative w-48 h-48"
         >
-          {/* 프로필 이미지 */}
           <img
             src={profileImg}
             alt="Profile"
             className="w-full h-full rounded-full border border-brand-500 object-cover bg-white shadow-sm"
           />
 
-          {/* 편집 버튼: 이미지 우측 하단 바깥쪽으로 배치 */}
           <motion.button
             whileHover={{ scale: 1.1 }}
             whileTap={{ scale: 0.9 }}
@@ -59,10 +53,8 @@ const ProfilePage = () => {
           transition={{ delay: 0.1 }}
           className="flex flex-col gap-6 items-center"
         >
-          {/* 닉네임 */}
           <div className="relative w-80 h-11">
             <input type="text" placeholder="닉네임" className={inputBaseStyle} />
-            {/* 중복 확인 버튼 */}
             <button
               type="button"
               className="absolute -right-[100px] top-2 w-24 h-7 bg-white rounded-2xl border-[0.5px] border-brand-500 shadow-[0px_1px_2px_0px_rgba(33,150,243,0.25)] text-brand-500 text-sm font-medium hover:bg-brand-50 transition-colors flex items-center justify-center pb-0.5 cursor-pointer"
@@ -71,12 +63,10 @@ const ProfilePage = () => {
             </button>
           </div>
 
-          {/* 비밀번호 */}
           <div className="relative w-80 h-11">
             <input type="password" placeholder="변경 비밀번호" className={inputBaseStyle} />
           </div>
 
-          {/* 비밀번호 확인 */}
           <div className="relative w-80 h-11">
             <input type="password" placeholder="변경 비밀번호 확인" className={inputBaseStyle} />
           </div>


### PR DESCRIPTION

## #️⃣ 연관된 이슈

 #31

## #️⃣ 작업 내용

활동내역(History) 페이지 UI 및 라우팅 구현

페이지 구현: src/pages/HistoryPage.tsx 생성 및 피그마 디자인(폰트, 색상, 테이블 레이아웃) 반영

라우팅: src/App.tsx에 /history 경로 추가

헤더 연결: src/components/Header.tsx 내 프로필 드롭다운의 'History' 버튼을 클릭하면 해당 페이지로 이동하도록 Link 연결

스타일링: 배경 블러 효과(Blue blur) 및 테이블 상세 스타일(Pretendard 폰트, 구분선 정렬 등) 적용

## #️⃣ 테스트 결과

> 페이지 이동: 헤더의 프로필 > History 클릭 시 정상적으로 페이지가 이동함을 확인했습니다.

UI 확인: 피그마 디자인과 동일하게 배경 위치(top-[40%]) 및 테이블 정렬(중앙 정렬)이 적용된 것을 확인했습니다.

데이터 렌더링: 예시 데이터(구글 API, 카카오톡 API 등)가 테이블에 올바르게 매핑되어 표시됩니다.

## #️⃣ 변경 사항 체크리스트

[x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (로컬 테스트 완료)
[x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)
<img width="3676" height="2570" alt="히스토리 원본크기 캡쳐" src="https://github.com/user-attachments/assets/2fb62b31-9518-4dab-b88a-0c5b246d36f6" />


