### PR TITLE
feat: 홈 스크롤 했을 때 구현 (#48)

### DIFF
--- a/src/components/HomePage/BottomButtonSection.tsx
+++ b/src/components/HomePage/BottomButtonSection.tsx
@@ -11,8 +11,6 @@ export default function BottomButtonSection({ onClick, isExpanded }: BottomButto
     <button
       type="button"
       onClick={onClick}
-      // ★ 위치 수정: top-24 -> top-32 (약 128px)
-      // 헤더와 겹치지 않고, 보내주신 이미지처럼 여백의 중간쯤에 위치하도록 내렸습니다.
       className={`fixed left-1/2 -translate-x-1/2 z-[9999] p-2 transition-all duration-500 ease-in-out focus:outline-none
         ${isExpanded ? 'top-32' : 'bottom-3'}
         ${!isExpanded && 'hover:-translate-y-1'}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,7 +6,7 @@ import BottomButtonSection from '@/components/HomePage/BottomButtonSection'
 import APICardSmall from '@/components/APICardSmall'
 import NewsCard from '@/components/NewsCard'
 
-// -------------------- 1. 데이터 정의 (변경 없음) --------------------
+// -------------------- 1. 데이터 정의 --------------------
 interface APIData {
   id: number
   title: string
@@ -164,6 +164,7 @@ const ScrollableSection = ({
     isDragging.current = true
     startX.current = e.clientX
     startIndicatorX.current = indicatorX
+    // eslint-disable-next-line
     document.body.style.userSelect = 'none'
     document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)
@@ -181,6 +182,7 @@ const ScrollableSection = ({
   }
   const handleMouseUp = () => {
     isDragging.current = false
+    // eslint-disable-next-line
     document.body.style.userSelect = ''
     document.removeEventListener('mousemove', handleMouseMove)
     document.removeEventListener('mouseup', handleMouseUp)
@@ -248,12 +250,9 @@ const HomePage = () => {
     if (showMore) window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
-  // ★★★ [원본 코드 복구] ★★★
-  // !showMore 일 때는 님께서 주신 원본 코드를 그대로 렌더링합니다.
-  // 불필요한 부모 div나 스타일을 일절 추가하지 않았습니다.
   if (!showMore) {
     return (
-      // 홈화면 (원본 구조 100% 유지)
+      // 홈화면
       <div className="flex flex-col items-center justify-center">
         <div className="relative w-full h-[calc(100vh-200px)] flex flex-col items-center justify-center gap-8">
           {/* 로고와 소개글*/}
@@ -266,7 +265,7 @@ const HomePage = () => {
           {!isSearchOpen && <SearchTagSection />}
         </div>
 
-        {/* 하단 버튼 (이벤트 연결만 추가됨) */}
+        {/* 하단 버튼*/}
         {!isSearchOpen && <BottomButtonSection onClick={toggleView} isExpanded={false} />}
       </div>
     )
@@ -281,7 +280,7 @@ const HomePage = () => {
         <ScrollableSection title="Suggest API" data={suggestAPIs} type="api" />
       </div>
 
-      {/* 버튼: 상단 위치 (expanded=true -> top-24, Down 아이콘) */}
+      {/* 하단 버튼 (상단 고정, Down 아이콘) */}
       <BottomButtonSection onClick={toggleView} isExpanded={true} />
     </div>
   )


### PR DESCRIPTION

## #️⃣ 연관된 이슈

#48 

## #️⃣ 작업 내용

이번 PR에서는 메인 홈페이지의 UI/UX 개선 및 컴포넌트 디자인 고도화를 진행했습니다.

1. HomePage 구조 개선 및 검색창 고정

뷰 전환(showMore 상태 변경) 시 검색창 위치가 미세하게 흔들리는 문제를 해결하기 위해, 메인 화면과 리스트 화면의 렌더링 로직을 분리했습니다.

리스트 화면 전환 시 부드러운 스크롤 동작과 애니메이션을 적용했습니다.

2. 하단 버튼(BottomButtonSection) 로직 및 위치 수정

버튼 클릭 시 아이콘이 ChevronUp ↔ ChevronDown으로 교체되도록 수정했습니다.

리스트가 펼쳐졌을 때 버튼의 위치를 헤더 아래 적절한 위치(top-32)로 조정하여 디자인 시안과 일치시켰습니다.

화면 전환 시 버튼이 사라지거나 깜빡이지 않도록 z-index를 최상위(z-[9999])로 설정하고 렌더링 위치를 조정했습니다.


3. 커스텀 가로 스크롤 (ScrollableSection)

BookmarkCarousel의 로직을 이식하여, 드래그가 가능한 커스텀 가로 스크롤바를 구현했습니다.

마우스 휠을 사용하여 가로 스크롤이 가능하도록 이벤트를 연동했습니다.

## #️⃣ 테스트 결과

UI 렌더링: 검색창 위치가 고정된 상태로 하단 리스트가 자연스럽게 열리고 닫히는지 확인했습니다.

버튼 동작: 화살표 버튼 클릭 시 상단(top-32)과 하단(bottom-3)을 오가며 아이콘이 정상적으로 변경됨을 확인했습니다.

스크롤: 커스텀 스크롤바를 드래그하거나 마우스 휠을 사용했을 때 카드 리스트가 좌우로 부드럽게 이동하는 것을 확인했습니다.

## #️⃣ 변경 사항 체크리스트
[x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (UI 테스트 수행)

[ ] 문서를 작성하거나 수정했나요? (필요한 경우)

[x] 코드 컨벤션에 따라 코드를 작성했나요?

[x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)
<img width="3676" height="3600" alt="원본크기  홈스크롤 구현" src="https://github.com/user-attachments/assets/f6fdc591-8367-4690-9ac7-68c5cff14304" />


## #️⃣ 리뷰 요구사항 (선택)
사이트 들어갔을때 첫번째로 뜨는 홈화면이 이상해지진 않았는지 검색창 위치가 괜찮은지, 상단과 하단의 화살표 버튼 위치는 괜찮은지 홈스크롤 페이지의  각 항목별 카드 리스트가 자연스럽게 이동하는지, 가로 스크롤바가 잘 작동하는지. 그리고 카드들 이상한 점은 없는지 ( 카드에 덜 적용된 효과가 있어 수정할게 있는거 같긴해요 알려주시면 수정하겠습니다.)