### PR TITLE
fix: 로고 클릭했을 때 메인으로 이동하게 하기 (#100)

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -87,12 +87,17 @@ const Header = () => {
       <nav className="grid h-20 w-full grid-cols-3 items-center justify-between overflow-visible">
         {/* 좌측 로고 및 타이틀 영역 메인 페이지로 이동 */}
         <div className="flex justify-start">
-          <Link to="/" className="flex items-center pt-2 gap-[7px] sm:pl-8 md:pl-16 lg:pl-32">
+          {/* [수정 포인트] 
+            Link 대신 a 태그를 사용했습니다.
+            이렇게 하면 로고 클릭 시 브라우저가 주소를 새로 로딩(Refresh)하므로,
+            HomePage의 showMore 상태가 false(초기화면)로 리셋됩니다.
+          */}
+          <a href="/" className="flex items-center pt-2 gap-[7px] sm:pl-8 md:pl-16 lg:pl-32">
             <img src={HomeLogo} alt="Home Logo Icon" />
             <span className="font-mono antialiased text-[27px] font-medium tracking-[-3px] text-brand-500">
               API Wiki
             </span>
-          </Link>
+          </a>
         </div>
 
         {/* 중앙 메뉴 */}


### PR DESCRIPTION

## #️⃣ 연관된 이슈

 #100 

## #️⃣ 작업 내용

헤더 로고 클릭 동작 수정 (Header.tsx)
기존 react-router-dom의 <Link> 컴포넌트를 표준 HTML <a> 태그로 변경하였습니다.
수정 이유: 메인 페이지에서 화살표를 눌러 상세 화면(showMore: true)으로 진입한 상태에서 로고를 클릭했을 때, SPA 특성상 상태가 
유지되어 초기 화면(인트로)으로 돌아가지 않는 문제가 있었습니다.

개선 결과: 로고 클릭 시 페이지를 새로고침(Reload)하여 메인 페이지의 상태를 초기화하고, 항상 최상단 인트로 화면이 보이도록 UX를 개선했습니다.

## #️⃣ 테스트 결과
- [X] 로컬 환경 UI 테스트 완료
메인 페이지 진입 -> 화살표 클릭하여 스크롤 뷰(상세 화면) 활성화
상단 'API Wiki' 로고 클릭
결과: 페이지가 새로고침되며 초기 인트로 화면으로 정상 복귀됨을 확인

- [X] 다른 페이지(Explore, Bookmark)에서 로고 클릭 시 메인으로 정상 이동 확인

## #️⃣ 변경 사항 체크리스트

- [X] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [X] 코드 컨벤션에 따라 코드를 작성했나요?
- [X] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?


