### PR TITLE
fix: Explorepage 및 APIDetailPage 에러 수정 (#108)

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -159,6 +159,7 @@ export type CategoryItem = {
 
 /** API 상세 조회 */
 export type ApiDetail = {
+  pricingType: string | undefined
   apiId: number
   name: string
   summary: string


### PR DESCRIPTION

## #️⃣ 연관된 이슈
#108 

## #️⃣ 작업 내용

Explore 페이지 무한 스크롤 버그 수정
무한 스크롤 시 데이터가 병합될 때 중복된 API ID가 포함되어 key 중복 에러가 발생하는 문제를 해결했습니다. (Set과 filter를 사용하여 중복 제거 로직 추가)

API 상세 페이지(APIDetailPage) 로직 개선
서버 데이터가 일부 비어있을 경우(null) 404 에러가 발생하거나 화면이 깨지는 현상을 수정했습니다.
데이터가 없을 때 임의로 'Free'로 표시하던 가짜(Mock) 로직을 제거하고, 서버 데이터가 없으면 '-'로 정직하게 표시하도록 변경했습니다.
데이터가 아예 없거나 API ID가 잘못된 경우, 명확한 에러 화면을 출력하도록 수정했습니다.

Home 페이지 링크 연결 안정화
홈 화면의 하드코딩된 카드(Spotify 등) 클릭 시, 실제 DB에 데이터가 없으면 404 페이지로 이동하는 대신 서버에 존재하는 유효한 API 상세 페이지로 연결되도록 안전장치(Safe Link)를 적용했습니다.

TypeScript 타입 정의 수정 (types/api.ts)
ApiDetail 인터페이스에 누락되어 있던 pricingType 속성을 추가하여, 상세 페이지에서 as 타입 단언을 사용하지 않고도 안전하게 접근할 수 있도록 개선했습니다.

## #️⃣ 테스트 결과

Explore 페이지: 무한 스크롤을 빠르게 내려도 콘솔창에 Encountered two children with the same key 경고가 뜨지 않고, 카드가 정상적으로 누적됨을 확인했습니다.
상세 페이지 (Spotify 등): 기존에 404 에러가 뜨던 API 카드를 클릭했을 때, 에러 없이 상세 페이지가 정상적으로 렌더링됨을 확인했습니다.
데이터 표시: 가격 정보가 없는 API의 경우, 'Free'로 잘못 표기되지 않고 '-'(공란)으로 정확히 표시됨을 확인했습니다.
홈 페이지: 추천/인기 카드 클릭 시  모두 유효한 페이지로 이동함을 확인했습니다.

## #️⃣ 변경 사항 체크리스트

- [X] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [X] 코드 컨벤션에 따라 코드를 작성했나요?
- [X] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?


