### PR TITLE
fix: ApiCard에서 리뷰 수와 providerCompany 표시 제거

### DIFF
--- a/src/components/APICard.tsx
+++ b/src/components/APICard.tsx
@@ -101,7 +101,7 @@ export default function APICard({
               {viewCounts.toLocaleString()} views
             </p>
             <p className="text-[#B0B0B0] text-xs mt-0.5">
-              {PRICING_LABEL[pricingType] ?? pricingType} · {providerCompany}
+              {PRICING_LABEL[pricingType] ?? pricingType}
             </p>
           </div>
         </div>


### PR DESCRIPTION
- ApiCard에서 리뷰 수와 providerCompany 표시 제거

<img width="431" height="298" alt="image" src="https://github.com/user-attachments/assets/16edd368-394a-404f-aa69-0bffd62d2c26" />

