### PR TITLE
fix: HomePage 내 중복 키 경고 해결 및 가로 휠 스크롤 간섭 제거 (#116)

### DIFF
--- a/src/components/BookmarkCarousel.tsx
+++ b/src/components/BookmarkCarousel.tsx
@@ -10,8 +10,9 @@ export default function BookmarkCarousel({ date, children }: BookmarkCarouselPro
   const scrollRef = useRef<HTMLDivElement>(null)
   const [indicatorX, setIndicatorX] = useState(0)
 
-  // ✅ 린트 에러 해결을 위한 상태 추가
+  // 린트 에러 해결을 위한 상태 관리
   const [isDragActive, setIsDragActive] = useState(false)
+  const [activeTarget, setActiveTarget] = useState<'handle' | 'content' | null>(null)
 
   const isDragging = useRef(false)
   const dragTarget = useRef<'handle' | 'content' | null>(null)
@@ -21,7 +22,7 @@ export default function BookmarkCarousel({ date, children }: BookmarkCarouselPro
 
   const MAX_MOVE = 24
 
-  // ✅ [린트 해결] 사이드 이펙트는 useEffect에서 관리
+  // [Lint 해결] document.body 스타일 변경은 useEffect에서 처리
   useEffect(() => {
     if (isDragActive) {
       document.body.style.userSelect = 'none'
@@ -42,7 +43,8 @@ export default function BookmarkCarousel({ date, children }: BookmarkCarouselPro
 
   const onDragStart = (e: React.MouseEvent, target: 'handle' | 'content') => {
     isDragging.current = true
-    setIsDragActive(true) // 드래그 활성화
+    setIsDragActive(true)
+    setActiveTarget(target)
     dragTarget.current = target
     startX.current = e.clientX
     if (scrollRef.current) startScrollLeft.current = scrollRef.current.scrollLeft
@@ -50,6 +52,7 @@ export default function BookmarkCarousel({ date, children }: BookmarkCarouselPro
 
     document.addEventListener('mousemove', onDragMove)
     document.addEventListener('mouseup', onDragEnd)
+    // 안전장치 추가
     document.addEventListener('mouseleave', onDragEnd)
   }
 
@@ -70,7 +73,8 @@ export default function BookmarkCarousel({ date, children }: BookmarkCarouselPro
 
   const onDragEnd = () => {
     isDragging.current = false
-    setIsDragActive(false) // 드래그 해제
+    setIsDragActive(false)
+    setActiveTarget(null)
     dragTarget.current = null
 
     if (scrollRef.current) {
@@ -94,9 +98,10 @@ export default function BookmarkCarousel({ date, children }: BookmarkCarouselPro
       <div
         ref={scrollRef}
         onMouseDown={(e) => onDragStart(e, 'content')}
+        // ✅ [핵심] 여기서 기본 드래그 막음 (로고 드래그 시 스크롤 되도록)
         onDragStart={(e) => e.preventDefault()}
         className={`flex gap-10 overflow-x-auto pb-4 pr-10 px-4 lg:px-0 no-scrollbar select-none ${
-          isDragging.current && dragTarget.current === 'content' ? 'cursor-grabbing' : 'cursor-grab'
+          activeTarget === 'content' ? 'cursor-grabbing' : 'cursor-grab'
         }`}
         style={{
           scrollbarWidth: 'none',


### PR DESCRIPTION


## #️⃣ 연관된 이슈

#116 

## #️⃣ 작업 내용

홈 페이지 리스트 렌더링 최적화 및 사용자 경험(UX) 개선중복 키(Duplicate Key) 에러 해결: HomePage.tsx에서 서버 데이터와 하드코딩 데이터를 매칭하는 과정 중 발생하던 key='40' 중복 문제를 해결했습니다.복합 키 적용 형식을 도입하여 서로 다른 섹션 간의 ID 충돌을 방지하고 컴포넌트의 정체성을 확보했습니다.휠 스크롤 간섭 제거: ScrollableSection 컴포넌트에서 휠 이벤트를 통한 가로 스크롤 로직(handleWheel)을 삭제했습니다.스크롤 방식 정립: 이제 마우스 휠로는 페이지 전체의 세로 이동만 가능하며, 카드 리스트의 가로 이동은 의도적인 **드래그(Drag)**를 통해서만 작동하도록 수정하여 스크롤 꼬임 현상을 방지했습니다.

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등
콘솔 경고 확인: 리액트 개발자 도구 콘솔에서 더 이상 "Encountered two children with the same key" 경고가 발생하지 않음을 확인했습니다.
UX 테스트: 마우스 휠(볼) 조작 시 가로 리스트가 멋대로 움직이지 않고 페이지 세로 스크롤만 정상 작동하는 것을 확인했습니다.
드래그 기능 검증: 마우스 클릭 후 드래그 시 가로 스크롤이 부드럽게 작동하며, 각 카드의 상세 페이지 이동(Maps)도 정상적으로 연결됨을 확인했습니다.
## #️⃣ 변경 사항 체크리스트

- [X] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [X] 코드 컨벤션에 따라 코드를 작성했나요?
- [X] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?



