### PR TITLE
fix:APICardSmall 이미지 표시수정 (#120)

### DIFF
--- a/src/components/APICardSmall.tsx
+++ b/src/components/APICardSmall.tsx
@@ -39,12 +39,12 @@ export default function APICardSmall({
       <div className="relative pl-4 xs:pl-6 sm:pl-8 h-full flex items-center">
         <div className="flex gap-2 xs:gap-3 sm:gap-4 items-center">
           {/* ✅ [수정] 아이콘 표시 영역 */}
-          <div className="w-14 h-14 xs:w-16 xs:h-16 sm:w-[70px] sm:h-[70px] rounded-lg xs:rounded-[10px] overflow-hidden flex-shrink-0 bg-white border border-brand-500/50 flex items-center justify-center shadow-sm">
+          <div className="w-14 h-14 xs:w-16 xs:h-16 sm:w-[70px] sm:h-[70px] rounded-lg xs:rounded-[10px] overflow-hidden flex-shrink-0 bg-white flex items-center justify-center shadow-sm">
             {!imgError ? (
               <img
                 src={logoUrl}
                 alt={name}
-                className="w-full h-full object-contain p-1 xs:p-1.5"
+                className="w-full h-full"
                 onError={() => setImgError(true)}
               />
             ) : (


### PR DESCRIPTION


## #️⃣ 연관된 이슈

#120 

## #️⃣ 작업 내용
apismallcard안 {/* ✅ [수정] 아이콘 표시 영역 */}
          <div className="w-14 h-14 xs:w-16 xs:h-16 sm:w-[70px] sm:h-[70px] rounded-lg xs:rounded-[10px] overflow-hidden flex-shrink-0 bg-white flex items-center justify-center shadow-sm"> 이 부분 이 줄을 이렇게 수정하여서 해결되었음

## #️⃣ 테스트 결과
이미지가 의도한 대로 카드 안에 잘 표시됨

## #️⃣ 변경 사항 체크리스트

- [X] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [X] 문서를 작성하거나 수정했나요? (필요한 경우)
- [X] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?
